### PR TITLE
Fix path for main field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "request-frame",
   "version": "1.0.2",
   "description": "requestAnimationFrame & cancelAnimationFrame polyfill for optimal cross-browser development.",
-  "main": "request-frame.js",
+  "main": "dist/request-frame.js",
   "directories": {
     "example": "example",
     "test": "test"


### PR DESCRIPTION
This minor fix is needed for tools that use the package.json main field, e.g. browserify
