### PR TITLE
Add window check to IIFE

### DIFF
--- a/src/amd-wrapper-end.js
+++ b/src/amd-wrapper-end.js
@@ -17,4 +17,4 @@ window.requestFrame = requestFrame;
 }
 /* global -module, -exports, -define */
 
-}(window));
+}((typeof window === "undefined" ? {} : window)));


### PR DESCRIPTION
This will let the polyfill be required in universal ("isomorphic") apps which do not polyfill the `window` object by default.
