### PR TITLE
removing dependencies that are not required

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-cli": "*",
     "babel-preset-es2015": "*",
     "babel-preset-modern-browsers": "*",
+    "babel-preset-es2015-rollup": "^1.2.0",
     "chai": "*",
     "gulp": "^3.9.1",
     "gulp-bump": "*",
@@ -61,7 +62,5 @@
     "rollup-watch": "*"
   },
   "dependencies": {
-    "babel-preset-es2015-rollup": "^1.2.0",
-    "dev": "^0.1.3"
   }
 }


### PR DESCRIPTION
I am facing this isssue in OSX and I don't think this dependency is required.

Please correct me if I am wrong otherwise please do consider this pull request

``` bash
npm ERR! Darwin 15.6.0
npm ERR! argv "/Users/chunkiat82/.nvm/versions/node/v6.3.1/bin/node" "/Users/chunkiat82/.nvm/versions/node/v6.3.1/bin/npm" "install"
npm ERR! node v6.3.1
npm ERR! npm  v3.10.8
npm ERR! code EBADPLATFORM

npm ERR! notsup Unsupported platform for inotify@1.4.1: wanted {"os":"linux","arch":"any"} (current: {"os":"darwin","arch":"x64"})
npm ERR! notsup Valid OS:    linux
npm ERR! notsup Valid Arch:  any
npm ERR! notsup Actual OS:   darwin
npm ERR! notsup Actual Arch: x64

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/rayho/github/chunkiat82/request-frame/npm-debug.log
```

`dev` has been deprecated -> https://github.com/iliakan/node-dev
